### PR TITLE
Alter the precalculated results for use with a docker container

### DIFF
--- a/websmash/default_settings.py
+++ b/websmash/default_settings.py
@@ -1,9 +1,10 @@
 from os import path
+
 ############# Configuration #############
 DEBUG = True
 SECRET_KEY = "development_key"
-RESULTS_PATH = path.join(path.dirname(path.dirname(__file__)), 'results')
-RESULTS_URL = '/upload'
+RESULTS_PATH = path.join(path.dirname(path.dirname(__file__)), "results")
+RESULTS_URL = "/upload"
 
 # Flask-Mail settings
 MAIL_SERVER = "mail.example.org"
@@ -13,6 +14,8 @@ DEFAULT_RECIPIENTS = ["bob@example.org"]
 # Flask-Redis settings
 REDIS_URL = "redis://localhost:6379/0"
 
+# precalculated results location. for sure change this
+PRECALCULATED_RESULTS = "/precalc"
+
 OLD_JOB_COUNT = 0
 #########################################
-

--- a/websmash/templates/files.html
+++ b/websmash/templates/files.html
@@ -1,0 +1,9 @@
+<ul>
+    {% for file in files %}
+    <li>
+        <a href="{{ (request.path + '/' if request.path != '/' else '') + file }}">
+            {{ (request.path + '/' if request.path != '/' else '') + file }}
+        </a>
+    </li>
+    {% endfor %}
+</ul>

--- a/websmash/templates/new.html
+++ b/websmash/templates/new.html
@@ -16,7 +16,7 @@
 </div>
 <ul class="nav nav-tabs">
   <li class="active"><a href="#nucl" data-toggle="tab">Nucleotide input</a></li>
-  <li><a href="./precalc/precalc/">Precalculated Results</a></li>
+  <li><a href="./precalc/">Precalculated Results</a></li>
   <li><a href="#job" data-toggle="tab">Results for existing job</a></li>
 </ul>
 <div class="tab-content">

--- a/websmash/templates/new.html
+++ b/websmash/templates/new.html
@@ -16,7 +16,7 @@
 </div>
 <ul class="nav nav-tabs">
   <li class="active"><a href="#nucl" data-toggle="tab">Nucleotide input</a></li>
-  <li><a href="./precalc/">Precalculated Results</a></li>
+  <li><a href="./precalc">Precalculated Results</a></li>
   <li><a href="#job" data-toggle="tab">Results for existing job</a></li>
 </ul>
 <div class="tab-content">

--- a/websmash/views.py
+++ b/websmash/views.py
@@ -1,4 +1,4 @@
-from flask import redirect, url_for, request, abort, \
+from flask import redirect, send_file, url_for, request, abort, \
                   render_template, jsonify
 from flask.ext.mail import Message
 import os
@@ -7,6 +7,8 @@ from werkzeug import secure_filename
 from websmash import app, mail, get_db
 from websmash.utils import generate_confirmation_mail
 from websmash.models import Job, Notice
+
+import default_settings as settings
 
 def _submit_job(redis_store, job):
     """Submit a new job"""
@@ -211,6 +213,27 @@ def server_status():
                    long_running=long_running, total_jobs=total_jobs,
                    ts_queued=ts_queued, ts_queued_m=ts_queued_m,
                    ts_timeconsuming=ts_timeconsuming, ts_timeconsuming_m=ts_timeconsuming_m)
+
+@app.route('/precalc', defaults={'req_path': ''})
+@app.route('/precalc/<path:req_path>')
+def dir_listing(req_path):
+    BASE_DIR = settings.PRECALCULATED_RESULTS
+
+    # Joining the base and the requested path
+    abs_path = os.path.join(BASE_DIR, req_path)
+
+    # Return 404 if path doesn't exist
+    if not os.path.exists(abs_path):
+        return abort(404)
+
+    # Check if path is a file and serve
+    if os.path.isfile(abs_path):
+        return send_file(abs_path)
+        
+
+    # Show directory contents
+    files = os.listdir(abs_path)
+    return render_template('files.html', files=files, path=req_path)
 
 
 def _get_oldest_job(queue):

--- a/websmash/views.py
+++ b/websmash/views.py
@@ -8,8 +8,6 @@ from websmash import app, mail, get_db
 from websmash.utils import generate_confirmation_mail
 from websmash.models import Job, Notice
 
-import default_settings as settings
-
 def _submit_job(redis_store, job):
     """Submit a new job"""
     redis_store.hmset(u'job:%s' % job.uid, job.get_dict())
@@ -217,7 +215,7 @@ def server_status():
 @app.route('/precalc', defaults={'req_path': ''})
 @app.route('/precalc/<path:req_path>')
 def dir_listing(req_path):
-    BASE_DIR = settings.PRECALCULATED_RESULTS
+    BASE_DIR = app.config['PRECALCULATED_RESULTS']
 
     # Joining the base and the requested path
     abs_path = os.path.join(BASE_DIR, req_path)

--- a/websmash/views.py
+++ b/websmash/views.py
@@ -230,7 +230,7 @@ def dir_listing(req_path):
         
 
     # Show directory contents
-    files = os.listdir(abs_path)
+    files = sorted(os.listdir(abs_path), key=lambda file: file)
     return render_template('files.html', files=files, path=req_path)
 
 


### PR DESCRIPTION
This introduces a configuration variable that allows you to specify the location of precalculated results. This is useful for if you are running this in a docker container.

Note that the default value of the precalculated_results field must be updated to reflect where these results are located. This change likely breaks a setup based on the static /precalc/precalc location if it was unaltered in code.